### PR TITLE
Hotfix forest sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**MetaDTA v2.0.3**
+**MetaDTA v2.0.4**
 
 MetaDTA is an online interactive application for conducting meta-analysis of diagnostic test accuracy studies (DTA) requiring no specialist software for the user to install but leveraging established analysis routines (specifically the lme4 package in R). The tool is interactive and uses an intuitive ‘point and click’ interface and presents results in visually intuitive and appealing ways. It is hoped that this tool will assist those in conducting DTA meta-analysis who are not statistical experts, and, in turn, increase the relevance of published meta-analyses, and in the long term contribute to improved healthcare decision making as a result.
 

--- a/app.R
+++ b/app.R
@@ -4041,9 +4041,14 @@ server <- function(input, output) {
     ifelse(nrow(data()) <=20, 400, 20*(nrow(data()))) # Reactive plot height based on number of studies
   })
   
-  # Forest plot pixel height varies based on the number of studies
-  forest_height <- reactive({
+  # Forest plot png pixel height varies based on the number of studies
+  forest_png_height <- reactive({
     ifelse(nrow(data()) <=20, 400, 20*(nrow(data())))
+  })
+  
+  # Forest plot pdf height varies based on the number of studies
+  forest_pdf_height <- reactive({
+    ifelse(nrow(data()) <=20, 6, 6 + 0.2*(nrow(data())-20))
   })
   
   # Allow users to download the sensitivity forest plot
@@ -4057,9 +4062,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file = file, height = forest_height())
+        png(file = file, height = forest_png_height())
       else
-        pdf(file)
+        pdf(file, height = forest_pdf_height())
       
       X <- data()
       D <- madad(X, correction.control = "any")
@@ -4079,9 +4084,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file, height = forest_height())
+        png(file, height = forest_png_height())
       else
-        pdf(file)
+        pdf(file, height = forest_pdf_height())
       
       X <- data()
       D <- madad(X, correction.control = "any")
@@ -8896,8 +8901,13 @@ server <- function(input, output) {
   })
   
   # Sensitivity forest plot pixel height varies based on the number of studies
-  sensitivity_height <- reactive({
+  subgroup_png_height <- reactive({
     ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist)))
+  })
+  
+  # Sensitivity forest plot pdf height varies based on the number of studies
+  subgroup_pdf_height <- reactive({
+    ifelse(length(input$triallist) <=20, 6, 6 + 0.2*(length(input$triallist)-20))
   })
   
   # Allow users to download the sensitivity forest plot
@@ -8911,9 +8921,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = sensitivity_height())
+        png(file, height = subgroup_png_height())
       else
-        pdf(file)
+        pdf(file, height = subgroup_pdf_height())
       
       adf <- data()
       X <- adf[input$triallist, ]
@@ -8933,11 +8943,12 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = sensitivity_height())
+        png(file, height = subgroup_png_height())
       else
-        pdf(file)
+        pdf(file, height = subgroup_pdf_height())
       
-      X <- data()
+      adf <- data()
+      X <- adf[input$triallist, ]
       D <- madad(X, correction.control = "any")
       forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
       

--- a/app.R
+++ b/app.R
@@ -4022,8 +4022,14 @@ server <- function(input, output) {
     else
       X <- data()
     D <- madad(X, correction.control = "any")
-    forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
+    
+    fplot <- forest(D, type = "sens", snames = X$author,
+           xlab = "Sensitivity", main = "Forest plot of sensitivity")
+    
+  }, height = function(){
+    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
   })
+  
   # Produce the forest plots for specificity
   output$forestMA_spec <- renderPlot({
     if(is.null(data())){return()}
@@ -4031,6 +4037,8 @@ server <- function(input, output) {
       X <- data()
     D <- madad(X, correction.control = "any")
     forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
+  }, height = function(){
+    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
   })
   
   # Allow users to download the sensitivity forest plot
@@ -8865,7 +8873,10 @@ server <- function(input, output) {
     X <- adf[input$triallist, ]
     D <- madad(X, correction.control = "any")
     forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
+  }, height = function(){
+    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
   })
+  
   # Produce the forest plots for specificity
   output$forestSA_spec <- renderPlot({
     if(is.null(data())){return()}
@@ -8873,7 +8884,10 @@ server <- function(input, output) {
       adf <- data()
     X <- adf[input$triallist, ]
     D <- madad(X, correction.control = "any")
+  
     forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
+  }, height = function(){
+    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
   })
   
   # Allow users to download the sensitivity forest plot

--- a/app.R
+++ b/app.R
@@ -4027,7 +4027,7 @@ server <- function(input, output) {
            xlab = "Sensitivity", main = "Forest plot of sensitivity")
     
   }, height = function(){
-    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
+    ifelse(nrow(data()) <=20, 400, 20*(nrow(data()))) # Reactive plot height based on number of studies
   })
   
   # Produce the forest plots for specificity
@@ -4038,7 +4038,7 @@ server <- function(input, output) {
     D <- madad(X, correction.control = "any")
     forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
   }, height = function(){
-    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
+    ifelse(nrow(data()) <=20, 400, 20*(nrow(data()))) # Reactive plot height based on number of studies
   })
   
   # Forest plot pixel height varies based on the number of studies
@@ -8879,7 +8879,7 @@ server <- function(input, output) {
     D <- madad(X, correction.control = "any")
     forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
   }, height = function(){
-    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
+    ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist))) # Reactive plot height based on number of studies
   })
   
   # Produce the forest plots for specificity
@@ -8892,7 +8892,7 @@ server <- function(input, output) {
   
     forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
   }, height = function(){
-    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
+    ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist))) # Reactive plot height based on number of studies
   })
   
   # Allow users to download the sensitivity forest plot

--- a/app.R
+++ b/app.R
@@ -3,6 +3,14 @@
 #  install.packages("BiocManager")
 #BiocManager::install(version = "3.11")
 #BiocManager::install("Rgraphviz")
+
+##########
+# Before deploying to shinyapps.io run the following lines in the console to avoid
+# failure to deploy due to BioConductor package
+# library(BiocManager)
+# options(repos = BiocManager::repositories())
+##########
+
 library(Rgraphviz)
 
 # Load packages

--- a/app.R
+++ b/app.R
@@ -37,6 +37,8 @@ library(yaml)
 library(foreach)
 library(Hmisc)
 
+source("forest_height.R") # Function to change forest plot height based on number of trials
+
 # Function to calculate sensitivity and specificity for each study
 study_level_outcomes <- function(data = NULL, subset=NULL, formula = NULL,
                                    TP="TP", FN="FN", FP="FP", TN="TN")
@@ -4028,38 +4030,29 @@ server <- function(input, output) {
   )
   
   # Produce the forest plots for sensitivity
-  output$forestMA_sens <- renderPlot({
-    if(is.null(data())){return()}
-    else
-      X <- data()
-    D <- madad(X, correction.control = "any")
-    
-    fplot <- forest(D, type = "sens", snames = X$author,
-           xlab = "Sensitivity", main = "Forest plot of sensitivity")
-    
-  }, height = function(){
-    ifelse(nrow(data()) <=20, 400, 20*(nrow(data()))) # Reactive plot height based on number of studies
+  observe({
+    output$forestMA_sens <- renderPlot({
+      if(is.null(data())){return()}
+      else
+        X <- data()
+      D <- madad(X, correction.control = "any")
+      
+      fplot <- forest(D, type = "sens", snames = X$author,
+             xlab = "Sensitivity", main = "Forest plot of sensitivity")
+      
+    }, height = forest_height(nrow(data()), "pixel")
+    )
   })
   
   # Produce the forest plots for specificity
-  output$forestMA_spec <- renderPlot({
-    if(is.null(data())){return()}
-    else
-      X <- data()
-    D <- madad(X, correction.control = "any")
-    forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
-  }, height = function(){
-    ifelse(nrow(data()) <=20, 400, 20*(nrow(data()))) # Reactive plot height based on number of studies
-  })
-  
-  # Forest plot png pixel height varies based on the number of studies
-  forest_png_height <- reactive({
-    ifelse(nrow(data()) <=20, 400, 20*(nrow(data())))
-  })
-  
-  # Forest plot pdf height varies based on the number of studies
-  forest_pdf_height <- reactive({
-    ifelse(nrow(data()) <=20, 6, 6 + 0.2*(nrow(data())-20))
+  observe({
+    output$forestMA_spec <- renderPlot({
+      if(is.null(data())){return()}
+      else
+        X <- data()
+      D <- madad(X, correction.control = "any")
+      forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
+    }, height = forest_height(nrow(data()), "pixel"))
   })
   
   # Allow users to download the sensitivity forest plot
@@ -4073,9 +4066,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file = file, height = forest_png_height())
+        png(file = file, height = forest_height(nrow(data()), "pixel"))
       else
-        pdf(file, height = forest_pdf_height())
+        pdf(file, height = forest_height(nrow(data()), "inch"))
       
       X <- data()
       D <- madad(X, correction.control = "any")
@@ -4095,9 +4088,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file, height = forest_png_height())
+        png(file, height = forest_height(nrow(data()), "pixel"))
       else
-        pdf(file, height = forest_pdf_height())
+        pdf(file, height = forest_height(nrow(data()), "inch"))
       
       X <- data()
       D <- madad(X, correction.control = "any")
@@ -8887,38 +8880,30 @@ server <- function(input, output) {
   )
   
   # Produce the forest plots for sensitivity
-  output$forestSA_sens <- renderPlot({
-    if(is.null(data())){return()}
-    else
-      adf <- data()
-    X <- adf[input$triallist, ]
-    D <- madad(X, correction.control = "any")
-    forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
-  }, height = function(){
-    ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist))) # Reactive plot height based on number of studies
+  observe ({
+    output$forestSA_sens <- renderPlot({
+      if(is.null(data())){return()}
+      else
+        adf <- data()
+      X <- adf[input$triallist, ]
+      D <- madad(X, correction.control = "any")
+      forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
+    }, height = forest_height(length(input$triallist), "pixel")
+    )
   })
   
   # Produce the forest plots for specificity
-  output$forestSA_spec <- renderPlot({
-    if(is.null(data())){return()}
-    else
-      adf <- data()
-    X <- adf[input$triallist, ]
-    D <- madad(X, correction.control = "any")
-  
-    forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
-  }, height = function(){
-    ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist))) # Reactive plot height based on number of studies
-  })
-  
-  # Sensitivity forest plot pixel height varies based on the number of studies
-  subgroup_png_height <- reactive({
-    ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist)))
-  })
-  
-  # Sensitivity forest plot pdf height varies based on the number of studies
-  subgroup_pdf_height <- reactive({
-    ifelse(length(input$triallist) <=20, 6, 6 + 0.2*(length(input$triallist)-20))
+  observe({
+    output$forestSA_spec <- renderPlot({
+      if(is.null(data())){return()}
+      else
+        adf <- data()
+      X <- adf[input$triallist, ]
+      D <- madad(X, correction.control = "any")
+    
+      forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
+    }, height = forest_height(length(input$triallist), "pixel")
+    )
   })
   
   # Allow users to download the sensitivity forest plot
@@ -8932,9 +8917,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = subgroup_png_height())
+        png(file, height = forest_height(length(input$triallist), "pixel"))
       else
-        pdf(file, height = subgroup_pdf_height())
+        pdf(file, height = forest_height(length(input$triallist), "inch"))
       
       adf <- data()
       X <- adf[input$triallist, ]
@@ -8954,9 +8939,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = subgroup_png_height())
+        png(file, height = forest_height(length(input$triallist), "pixel"))
       else
-        pdf(file, height = subgroup_pdf_height())
+        pdf(file, height = forest_height(length(input$triallist), "inch"))
       
       adf <- data()
       X <- adf[input$triallist, ]

--- a/app.R
+++ b/app.R
@@ -4027,7 +4027,7 @@ server <- function(input, output) {
            xlab = "Sensitivity", main = "Forest plot of sensitivity")
     
   }, height = function(){
-    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
+    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
   })
   
   # Produce the forest plots for specificity
@@ -4038,7 +4038,12 @@ server <- function(input, output) {
     D <- madad(X, correction.control = "any")
     forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
   }, height = function(){
-    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
+    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
+  })
+  
+  # Forest plot pixel height varies based on the number of studies
+  forest_height <- reactive({
+    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60)
   })
   
   # Allow users to download the sensitivity forest plot
@@ -4052,7 +4057,7 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file)
+        png(file = file, height = forest_height())
       else
         pdf(file)
       
@@ -4074,7 +4079,7 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file)
+        png(file, height = forest_height())
       else
         pdf(file)
       
@@ -8874,7 +8879,7 @@ server <- function(input, output) {
     D <- madad(X, correction.control = "any")
     forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
   }, height = function(){
-    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
+    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
   })
   
   # Produce the forest plots for specificity
@@ -8887,7 +8892,7 @@ server <- function(input, output) {
   
     forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
   }, height = function(){
-    ifelse(nrow(data()) <=20, 400, 20*nrow(data())) # Reactive plot height based on number of studies
+    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60) # Reactive plot height based on number of studies
   })
   
   # Allow users to download the sensitivity forest plot
@@ -8901,7 +8906,7 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file)
+        png(file, height = forest_height())
       else
         pdf(file)
       
@@ -8909,7 +8914,6 @@ server <- function(input, output) {
       X <- adf[input$triallist, ]
       D <- madad(X, correction.control = "any")
       forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
-      
       dev.off()
     })
   
@@ -8924,7 +8928,7 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file)
+        png(file, height = forest_height())
       else
         pdf(file)
       

--- a/app.R
+++ b/app.R
@@ -4040,7 +4040,7 @@ server <- function(input, output) {
       fplot <- forest(D, type = "sens", snames = X$author,
              xlab = "Sensitivity", main = "Forest plot of sensitivity")
       
-    }, height = forest_height(nrow(data()), "pixel")
+    }, height = calculate_forest_height_pixel(nrow(data()))
     )
   })
   
@@ -4052,7 +4052,8 @@ server <- function(input, output) {
         X <- data()
       D <- madad(X, correction.control = "any")
       forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
-    }, height = forest_height(nrow(data()), "pixel"))
+    }, height = calculate_forest_height_pixel(nrow(data()))
+    )
   })
   
   # Allow users to download the sensitivity forest plot
@@ -4066,9 +4067,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file = file, height = forest_height(nrow(data()), "pixel"))
+        png(file = file, height = calculate_forest_height_pixel(nrow(data())))
       else
-        pdf(file, height = forest_height(nrow(data()), "inch"))
+        pdf(file, height = calculate_forest_height_pdf(nrow(data())))
       
       X <- data()
       D <- madad(X, correction.control = "any")
@@ -4088,9 +4089,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest == "png")
-        png(file, height = forest_height(nrow(data()), "pixel"))
+        png(file, height = calculate_forest_height_pixel(nrow(data())))
       else
-        pdf(file, height = forest_height(nrow(data()), "inch"))
+        pdf(file, height = calculate_forest_height_pdf(nrow(data())))
       
       X <- data()
       D <- madad(X, correction.control = "any")
@@ -8888,7 +8889,7 @@ server <- function(input, output) {
       X <- adf[input$triallist, ]
       D <- madad(X, correction.control = "any")
       forest(D, type = "sens", snames = X$author, xlab = "Sensitivity", main = "Forest plot of sensitivity")
-    }, height = forest_height(length(input$triallist), "pixel")
+    }, height = calculate_forest_height_pixel(length(input$triallist))
     )
   })
   
@@ -8902,7 +8903,7 @@ server <- function(input, output) {
       D <- madad(X, correction.control = "any")
     
       forest(D, type = "spec", snames = X$author, xlab = "Specificity", main = "Forest plot of specificity")
-    }, height = forest_height(length(input$triallist), "pixel")
+    }, height = calculate_forest_height_pixel(length(input$triallist))
     )
   })
   
@@ -8917,9 +8918,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = forest_height(length(input$triallist), "pixel"))
+        png(file, height = calculate_forest_height_pixel(length(input$triallist)))
       else
-        pdf(file, height = forest_height(length(input$triallist), "inch"))
+        pdf(file, height = calculate_forest_height_pdf(length(input$triallist)))
       
       adf <- data()
       X <- adf[input$triallist, ]
@@ -8939,9 +8940,9 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = forest_height(length(input$triallist), "pixel"))
+        png(file, height = calculate_forest_height_pixel(length(input$triallist)))
       else
-        pdf(file, height = forest_height(length(input$triallist), "inch"))
+        pdf(file, height = calculate_forest_height_pdf(length(input$triallist)))
       
       adf <- data()
       X <- adf[input$triallist, ]

--- a/app.R
+++ b/app.R
@@ -4043,7 +4043,7 @@ server <- function(input, output) {
   
   # Forest plot pixel height varies based on the number of studies
   forest_height <- reactive({
-    ifelse(nrow(data()) <=25, 420, 15*(nrow(data())-1) + 60)
+    ifelse(nrow(data()) <=20, 400, 20*(nrow(data())))
   })
   
   # Allow users to download the sensitivity forest plot
@@ -8895,6 +8895,11 @@ server <- function(input, output) {
     ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist))) # Reactive plot height based on number of studies
   })
   
+  # Sensitivity forest plot pixel height varies based on the number of studies
+  sensitivity_height <- reactive({
+    ifelse(length(input$triallist) <=20, 400, 20*(length(input$triallist)))
+  })
+  
   # Allow users to download the sensitivity forest plot
   output$download_forestSA_sens <- downloadHandler(
     # Speicfy the file name (either roc.png or roc.pdf)
@@ -8906,7 +8911,7 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = forest_height())
+        png(file, height = sensitivity_height())
       else
         pdf(file)
       
@@ -8928,7 +8933,7 @@ server <- function(input, output) {
       # create the plot
       # close the device
       if(input$filetype_forest2 == "png")
-        png(file, height = forest_height())
+        png(file, height = sensitivity_height())
       else
         pdf(file)
       

--- a/app.R
+++ b/app.R
@@ -101,7 +101,7 @@ ui <- navbarPage(title = "MetaDTA: Diagnostic Test Accuracy Meta-analysis",
                  
                  # Start with a home tab
                  tabPanel("Home", 
-                          h1("MetaDTA: Diagnostic Test Accuracy Meta-Analysis v2.0.3 (30th May 2023)"),
+                          h1("MetaDTA: Diagnostic Test Accuracy Meta-Analysis v2.0.4 (14th June 2023)"),
                           br(),
                           h4("Version 2.0 is the version as described in the paper:",
                              tags$a(href="https://onlinelibrary.wiley.com/doi/full/10.1002/jrsm.1439", "Patel A, Cooper NJ, Freeman SC, Sutton AJ. Graphical enhancements to summary receiver operating charcateristic plots to facilitate the analysis and reporting of meta-analysis of diagnostic test accuracy data. Research Synthesis Methods 2020, https://doi.org/10.1002/jrsm.1439.
@@ -143,6 +143,9 @@ ui <- navbarPage(title = "MetaDTA: Diagnostic Test Accuracy Meta-analysis",
                           p("An interactive primer on diagnostic test accuracy can be found at:"),
                           tags$a(href="https://crsu.shinyapps.io/diagprimer/", "https://crsu.shinyapps.io/diagprimer/", target="_blank"),
                           br(),
+                          br(),
+                          p("Updates from v2.0.3 to v2.0.4"),
+                          p("Forest plots display correctly for analysis with larger numbers of studies"),
                           br(),
                           p("Updates from v2.0.2 to v2.0.3"),
                           p("Video tutorial from ESMARConf2023 added"),
@@ -698,7 +701,7 @@ server <- function(input, output) {
   #Download User Guide
   # Allow users the option to download the standard example dataset
   output$downloadUG <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("MetaDTA User Guide v1_0.pdf")
     },
@@ -735,7 +738,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the standard example dataset
   output$downloadData1 <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("Standard.csv")
     },
@@ -750,7 +753,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the quality assessment example dataset
   output$downloadData2 <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("QA.csv")
     },
@@ -765,7 +768,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the covariate example dataset
   output$downloadData3 <- downloadHandler(
-    # Speicfy the file name
+    # Specify the file name
     filename = function(){
       paste("Cov.csv")
     },
@@ -780,7 +783,7 @@ server <- function(input, output) {
 
   # Allow users the option to download the quality assessment and covariate example dataset
   output$downloadData4 <- downloadHandler(
-    # Speicfy the file name
+    # Specify the file name
     filename = function(){
       paste("QA_Cov.csv")
     },
@@ -985,7 +988,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the table of sens, spec for each trial
   output$downloadTable <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("table.csv")
     },
@@ -2074,7 +2077,7 @@ server <- function(input, output) {
   
   # Allow users to download the interactive SROC curve
   output$downloadROC <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("roc", input$filetype, sep=".")
     },
@@ -3501,7 +3504,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the table of statistics
   output$downloadStatTable <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("statTable.csv")
     },
@@ -3779,7 +3782,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the parameter estimates
   output$downloadParameters <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("Parameters.csv")
     },
@@ -3933,7 +3936,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the RevMan parameters
   output$downloadRevMan <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("RevMan.csv")
     },
@@ -4053,7 +4056,7 @@ server <- function(input, output) {
   
   # Allow users to download the sensitivity forest plot
   output$download_forestMA_sens <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("Sensitivity Forest Plot", input$filetype_forest, sep=".")
     },
@@ -4075,7 +4078,7 @@ server <- function(input, output) {
   
   # Allow users to download the specificity forest plot
   output$download_forestMA_spec <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("Specificity Forest Plot", input$filetype_forest, sep=".")
     },
@@ -6296,7 +6299,7 @@ server <- function(input, output) {
 
   # Allow users to download the sensitivity analysis SROC curve
   output$downloadROC_sa <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("roc_sa", input$filetype2, sep=".")
     },
@@ -8361,7 +8364,7 @@ server <- function(input, output) {
 
   # Allow users the option to download the table of statistics for included trials only
   output$downloadSATable <- downloadHandler(
-    # Speicfy the file name
+    # Specify the file name
     filename = function(){
       paste("SATable.csv")
     },
@@ -8636,7 +8639,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the parameter estimates
   output$downloadParameters2 <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("Parameters_SA.csv")
     },
@@ -8791,7 +8794,7 @@ server <- function(input, output) {
   
   # Allow users the option to download the RevMan parameters
   output$downloadRevMan2 <- downloadHandler(
-    # Speicfy the file name 
+    # Specify the file name 
     filename = function(){
       paste("RevMan_SA.csv")
     },
@@ -8912,7 +8915,7 @@ server <- function(input, output) {
   
   # Allow users to download the sensitivity forest plot
   output$download_forestSA_sens <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("Sensitivity Forest Plot_SA", input$filetype_forest2, sep=".")
     },
@@ -8934,7 +8937,7 @@ server <- function(input, output) {
   
   # Allow users to download the specificity forest plot
   output$download_forestSA_spec <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("Specificity Forest Plot_SA", input$filetype_forest2, sep=".")
     },
@@ -9333,7 +9336,7 @@ server <- function(input, output) {
   
   # Allow users to download the meta-analysis tree diagram
   output$downloadPrev_MA <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("MA_tree", input$filetype3, sep=".")
     },
@@ -9523,7 +9526,7 @@ server <- function(input, output) {
   
   # Allow users to download the meta-analysis tree diagram
   output$downloadPrev_SA <- downloadHandler(
-    # Speicfy the file name (either roc.png or roc.pdf)
+    # Specify the file name (either roc.png or roc.pdf)
     filename = function(){
       paste("SA_tree", input$filetype3, sep=".")
     },

--- a/forest_height.R
+++ b/forest_height.R
@@ -1,25 +1,29 @@
-# Function to decide height of forest plots based on the number of studies
-# and the output format
+# Function to decide pixel height of forest plots based on the number of studies
 # 
 # param studies
-# A number (an int). The number of studies to be plotted.
-# param tab 
-# A string representing the way the plot height is measured
-# "pixel" for png files or plots rendered in the app 
-# "inch" for pdf files
-#
+# A positive number (an int). The number of studies to be plotted.
 # return 
 # A number 
-# Height in pixels for png plots
+# Height in pixels (for png plots)
+#
+# author
+# NVB
+
+calculate_forest_height_pixel <- function(studies) {
+  ifelse(studies <=20, 400, 400 + 15*(studies-20))
+}
+
+# Function to decide inch height of pdf forest plots based on the number of studies
+# 
+# param studies
+# A positive number (an int). The number of studies to be plotted.
+# return 
+# A number 
 # Height in inches for pdf plots
 #
 # author
 # NVB
 
-forest_height <- function(studies, measure){
-  if (measure == "pixel") {
-    ifelse(studies <=20, 400, 20*studies)
-  } else if (measure == "inch") {
-    ifelse(studies <=20, 6, 6 + 0.2*(studies-20))
-  }
+calculate_forest_height_pdf <- function(studies) {
+  ifelse(studies <=25, 6, 6 + 0.2*(studies-25))
 }

--- a/forest_height.R
+++ b/forest_height.R
@@ -1,0 +1,25 @@
+# Function to decide height of forest plots based on the number of studies
+# and the output format
+# 
+# param studies
+# A number (an int). The number of studies to be plotted.
+# param tab 
+# A string representing the way the plot height is measured
+# "pixel" for png files or plots rendered in the app 
+# "inch" for pdf files
+#
+# return 
+# A number 
+# Height in pixels for png plots
+# Height in inches for pdf plots
+#
+# author
+# NVB
+
+forest_height <- function(studies, measure){
+  if (measure == "pixel") {
+    ifelse(studies <=20, 400, 20*studies)
+  } else if (measure == "inch") {
+    ifelse(studies <=20, 6, 6 + 0.2*(studies-20))
+  }
+}


### PR DESCRIPTION
Fixes issue #1 

Forest plots and their associated png and pdf download files now increase in height when there are more than 20 studies, so that each study is displayed clearly.

In the sensitivity analysis tab, the plot height is based on the number of studies that has been selected as opposed to the total number of studies.

The version number has been incremented in the app and the readme file and the update has been listed on the front page of the app.

Minor typo corrected.

Comment added to aid with deployment of BioConductor package in the future.

The larger plots do require the user to scroll down within the plot to view all the studies. One potential improvement would be to include some text to advise the user of this, if it does not seem obvious.